### PR TITLE
Fix visualization of Qubit state

### DIFF
--- a/src/quantumstateinput.ts
+++ b/src/quantumstateinput.ts
@@ -1,6 +1,6 @@
 import { acos, asin, cos, pi, sin, exp, complex, prod, round, format, multiply } from 'mathjs';
 import * as math from 'mathjs';
-import { ketStr } from './utils';
+import { extendedComplexString, ketStr } from './utils';
 // import { mathjax } from 'mathjax-full/js/mathjax';
 // import { MathJax } from 'mathjax-full/js/components/global';
 // import { MathJax } from 'mathjax-full/js/mathjax';
@@ -190,7 +190,7 @@ export class QuantumStateInput {
     // phi = phi || parseFloat(this.phase.value);
     // <!-- <td> + exp(i${phi}π)</td> -->
     let ex = exp(prod(complex(0, 1), parseFloat(phi), pi));
-    (ex as unknown as math.Complex).re = 0;
+    //(ex as unknown as math.Complex).re = 0;
     this.qubitFormula.innerHTML = `
       \\begin{alignat}{3}
       \\large  |ψ⟩
@@ -218,7 +218,7 @@ export class QuantumStateInput {
         notation: 'fixed',
         precision: 2,
       })} %\\cdot
-      && \\large \\: ${round(ex, 2).toString()}
+      && \\large  \\:( ${extendedComplexString(round(ex, 2) as unknown as math.Complex)} )
       && \\large ${ketStr('1', false)}
       \\end{alignat}
       `;

--- a/src/quantumstateinput.ts
+++ b/src/quantumstateinput.ts
@@ -189,7 +189,9 @@ export class QuantumStateInput {
     // theta = theta || this.amplitude[0].value;
     // phi = phi || parseFloat(this.phase.value);
     // <!-- <td> + exp(i${phi}π)</td> -->
-    let ex = exp(prod(complex(0, 1), parseFloat(phi), pi));
+    let ex = exp(prod(complex(0, 1), parseFloat(phi), pi)) as unknown as math.Complex;
+    let sinT = sin((theta * pi) / 2);
+    let ket1Scalar = round(multiply(ex as math.MathType,sinT as math.MathType) as math.Complex, 2);
     //(ex as unknown as math.Complex).re = 0;
     this.qubitFormula.innerHTML = `
       \\begin{alignat}{3}
@@ -213,12 +215,16 @@ export class QuantumStateInput {
         precision: 2,
       })}
       && \\large ${ketStr('0', false)}
-      %&& \\large + && \\large ${round(sin((theta * pi) / 2), 4)} %\\cdot
-      && \\large + && \\large ${format(sin((theta * pi) / 2), {
+      %&& \\large + && \\large ${round(ket1Scalar.re, 4)} %\\cdot
+      && \\large + && (\\large ${format(ket1Scalar.re, {
         notation: 'fixed',
         precision: 2,
       })} %\\cdot
-      && \\large  \\:( ${extendedComplexString(round(ex, 2) as unknown as math.Complex)} )
+      % && \\large  \\: ${(ket1Scalar.im >= 0?'+ ':'')+round(ket1Scalar.im, 4)}
+      && \\large  \\: ${(ket1Scalar.im >= 0?'+ ':'')+format(ket1Scalar.im,{
+        notation: 'fixed',
+        precision: 2
+      })+'i'} )
       && \\large ${ketStr('1', false)}
       \\end{alignat}
       `;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ import {
   TubeGeometry,
   Vector3,
 } from 'three';
-import { cos, equal, sin } from 'mathjs';
+import { Complex, cos, equal, sin } from 'mathjs';
 
 type Map<T> = { [key: string]: T };
 export type IntersectionMap = Map<Intersection<Object3D>>;
@@ -213,4 +213,43 @@ export function linSpace(startValue, stopValue, cardinality) {
     arr.push(startValue + step * i);
   }
   return arr;
+}
+
+export function extendedComplexString(complex: Complex) : string {
+  var re = complex['re'];
+  var im = complex['im'];
+  var ret = "";
+
+  if (complex['isNaN']()) {
+    return 'NaN';
+  }
+
+  if (complex['isInfinite']()) {
+    return 'Infinity';
+  }
+
+  if (Math.abs(re) < complex['EPSILON']) {
+    re = 0;
+  }
+
+  if (Math.abs(im) < complex['EPSILON']) {
+    im = 0;
+  }
+  if (re < 0) {
+    re = -re;
+    ret += "-";
+  } else {
+    ret += "+";
+  }
+  ret += re.toFixed(2);
+  ret += " ";
+  if (im < 0) {
+    im = -im;
+    ret += "-";
+  } else {
+    ret += "+";
+  }
+  ret += " ";
+  ret += im.toFixed(2);
+  return ret + "i";
 }


### PR DESCRIPTION
In the visualization of the qubit state as sum of ket, there was an error in scalar value of ket 1.
When multiplying sin(theta/2) by e^iphi, the second part is a complex number, and only the imaginary part is considered, thus leading to an incorrect representation.
In the solution I provided the multiplication of the two factor is complete.
Might be improved graphically, but at least is mathematically correct.